### PR TITLE
feat: Add IE 11 download support

### DIFF
--- a/src/lib/csv.directive.ts
+++ b/src/lib/csv.directive.ts
@@ -1,7 +1,7 @@
-import { Directive, HostBinding, Input, OnChanges } from '@angular/core';
+import { Directive, HostBinding, HostListener, Input, OnChanges } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
-import { buildURI, HeaderObj } from './util';
+import { blob, buildURI, HeaderObj } from './util';
 
 @Directive({ selector: '[csvLink]' })
 export class CsvDirective implements OnChanges {
@@ -21,8 +21,19 @@ export class CsvDirective implements OnChanges {
   @HostBinding() href?: SafeResourceUrl;
   /** filename */
   @HostBinding() download = 'data.csv';
-  @Input() @HostBinding() target = '_blank';
+  @Input() @HostBinding() target = this.isIEBrowser() ? '' : '_blank';
   constructor(private sanitizer: DomSanitizer) {}
+
+  @HostListener('click') onClick() {
+    if (this.isIEBrowser()) { //IE handling
+      const file = blob(this.data, this.uFEFF, this.headers, this.delimiter);
+      window.navigator.msSaveBlob(file, this.download);
+    }
+  }
+
+  isIEBrowser(): boolean {
+    return !!window.navigator.msSaveOrOpenBlob;
+  }
 
   ngOnChanges() {
     this.href = this.sanitizer.bypassSecurityTrustResourceUrl(

--- a/src/lib/util.spec.ts
+++ b/src/lib/util.spec.ts
@@ -1,5 +1,6 @@
 import {
   arrays2csv,
+  blob,
   buildURI,
   isArrays,
   isJsons,
@@ -200,6 +201,19 @@ describe(`core::toCSV`, () => {
 
   it(`accepts data as "string" `, () => {
     expect(() => toCSV(fixtures.string)).toBeTruthy();
+  });
+});
+
+describe(`core::blob`, () => {
+  const fixtures = {
+    string: 'Xy',
+    arrays: [['a', 'b'], ['c', 'd']],
+    jsons: [{}, {}],
+  };
+
+  it(`creates blob instance`, () => {
+    expect(blob(fixtures.arrays)).toBeTruthy();
+    expect(blob(fixtures.string)).toBeTruthy();
   });
 });
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -92,13 +92,21 @@ export function toCSV(
   );
 }
 
-export function buildURI(
+export function blob(
   data: string | string[][] | { [key: string]: string }[] | any[],
   uFEFF = true,
   headers?: string[] | HeaderObj[],
   delimiter?: string,
 ) {
   const csv = toCSV(data, headers, delimiter);
-  const blob = new Blob([uFEFF ? '\uFEFF' : '', csv], { type: 'text/csv' });
-  return URL.createObjectURL(blob);
+  return new Blob([uFEFF ? '\uFEFF' : '', csv], { type: 'text/csv' });
+}
+
+export function buildURI(
+  data: string | string[][] | { [key: string]: string }[] | any[],
+  uFEFF = true,
+  headers?: string[] | HeaderObj[],
+  delimiter?: string,
+) {
+  return URL.createObjectURL(blob(data, uFEFF, headers, delimiter));
 }


### PR DESCRIPTION
This PR adds IE 11 download support. I will be glad if this is reviewed and merged :)

PS: the demo site https://ngx-csv.netlify.com/ does not work on IE 11. I had to apply some walk-arounds (See https://github.com/angular/angular-cli/issues/14455)  but did not want to add to this PR. Thanks in advance!